### PR TITLE
Ansible Galaxy の E306のエラー対応

### DIFF
--- a/tasks/setup_php.yml
+++ b/tasks/setup_php.yml
@@ -2,6 +2,8 @@
 - name: Get the conf.d directory path.
   shell: |
     php -i | grep -e "php.d$" -e "conf.d$" | awk '{print $9}'
+  args:
+    executable: /bin/bash
   changed_when: false
   register: _php_conf_d_dir
 


### PR DESCRIPTION
多分これが原因。
とりあえず、記載通りに修正してみた。

https://github.com/ansible/ansible-lint/issues/497